### PR TITLE
Update Berksfile.lock to be in sync with the latest Berksfile.

### DIFF
--- a/Berksfile.lock
+++ b/Berksfile.lock
@@ -1,25 +1,108 @@
-cookbook 'razor', :locked_version => '0.3.2'
-cookbook 'dhcp', :git => 'git://github.com/fnichol/dhcp-cookbook.git', :ref => 'craigtracey-with-upstart'
-cookbook 'router', :path => './cookbooks-internal/router'
-cookbook 'puppet', :locked_version => '0.2.0'
-cookbook 'chef-server', :git => 'git://github.com/opscode-cookbooks/chef-server.git', :ref => '125e93b5f79284c2aad3c6548d0faead9a0533b2'
-cookbook 'djbdns', :locked_version => '1.0.0'
-cookbook 'apache2', :locked_version => '1.4.2'
-cookbook 'chef-client', :locked_version => '2.1.6'
-cookbook 'build-essential', :locked_version => '1.3.2'
-cookbook 'git', :locked_version => '2.1.2'
-cookbook 'dmg', :locked_version => '1.1.0'
-cookbook 'runit', :locked_version => '0.16.2'
-cookbook 'yum', :locked_version => '2.1.0'
-cookbook 'windows', :locked_version => '1.7.0'
-cookbook 'chef_handler', :locked_version => '1.1.4'
-cookbook 'tftp', :locked_version => '1.1.0'
-cookbook 'mongodb', :locked_version => '0.11.0'
-cookbook 'apt', :locked_version => '1.8.0'
-cookbook 'postgresql', :locked_version => '2.1.0'
-cookbook 'openssl', :locked_version => '1.0.0'
-cookbook 'nodejs', :locked_version => '1.0.1'
-cookbook 'daemontools', :locked_version => '1.0.0'
-cookbook 'ucspi-tcp', :locked_version => '1.0.0'
-cookbook 'bluepill', :locked_version => '2.2.0'
-cookbook 'rsyslog', :locked_version => '1.4.0'
+{
+  "sha": "93e4b0688f42460b6ca60055fb0bf57d641398c3",
+  "sources": {
+    "apt": {
+      "locked_version": "2.0.0"
+    },
+    "razor": {
+      "locked_version": "0.5.0"
+    },
+    "dhcp": {
+      "locked_version": "2.0.0",
+      "git": "git://github.com/spheromak/dhcp-cook.git",
+      "ref": "dc054895e03c45fea951a7a509aad915512056bd"
+    },
+    "router": {
+      "path": "./cookbooks-internal/router"
+    },
+    "puppet": {
+      "locked_version": "0.2.0"
+    },
+    "chef-server": {
+      "locked_version": "2.0.0",
+      "git": "git://github.com/opscode-cookbooks/chef-server.git",
+      "ref": "8f8d3558abe7b5e70cc45c940d7ef05dac96f233"
+    },
+    "djbdns": {
+      "locked_version": "1.0.2"
+    },
+    "apache2": {
+      "locked_version": "1.6.6"
+    },
+    "chef-client": {
+      "locked_version": "3.0.4"
+    },
+    "build-essential": {
+      "locked_version": "1.4.0"
+    },
+    "git": {
+      "locked_version": "2.5.2"
+    },
+    "dmg": {
+      "locked_version": "1.1.0"
+    },
+    "yum": {
+      "locked_version": "2.3.0"
+    },
+    "windows": {
+      "locked_version": "1.10.0"
+    },
+    "chef_handler": {
+      "locked_version": "1.1.4"
+    },
+    "runit": {
+      "locked_version": "1.1.6",
+      "constraint": ">= 1.0.0"
+    },
+    "tftp": {
+      "locked_version": "1.1.0"
+    },
+    "mongodb": {
+      "locked_version": "0.11.0"
+    },
+    "postgresql": {
+      "locked_version": "3.0.2"
+    },
+    "openssl": {
+      "locked_version": "1.0.2"
+    },
+    "database": {
+      "locked_version": "1.4.0"
+    },
+    "mysql": {
+      "locked_version": "3.0.2",
+      "constraint": ">= 1.3.0"
+    },
+    "aws": {
+      "locked_version": "0.101.2"
+    },
+    "xfs": {
+      "locked_version": "1.1.0"
+    },
+    "nodejs": {
+      "locked_version": "1.1.2"
+    },
+    "ruby-helper": {
+      "locked_version": "0.0.1"
+    },
+    "helpers-databags": {
+      "locked_version": "1.0.0"
+    },
+    "daemontools": {
+      "locked_version": "1.0.2"
+    },
+    "ucspi-tcp": {
+      "locked_version": "1.0.2"
+    },
+    "bluepill": {
+      "locked_version": "2.2.2"
+    },
+    "rsyslog": {
+      "locked_version": "1.6.0"
+    },
+    "cron": {
+      "locked_version": "1.2.4",
+      "constraint": ">= 1.2.0"
+    }
+  }
+}


### PR DESCRIPTION
Berksfile specifies the dhcp cookbook from git://github.com/spheromak/dhcp-cook.git,
while the checked in Berksfile.lock pointed to git://github.com/fnichol/dhcp-cookbook.git,
which does not work wihout `data_bags/dhcp/default.json`, which was removed from
this repo on 17 April.
